### PR TITLE
Modified interface to `personal-files` to allow access to hidden files/folders

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: universal-ctags # you probably want to 'snapcraft register <name>'
-version: '0.1.1' # just for humans, typically '1.2+git' or '1.3.2'
+version: '0.2.0' # just for humans, typically '1.2+git' or '1.3.2'
 summary: Symbol tags for tracing code # 79 char long summary
 description: |
   The goal of the project is preparing and maintaining common/unified working
@@ -12,7 +12,7 @@ apps:
   universal-ctags:
     command: ctags
     plugs:
-      - home
+      - personal-files
 
 parts:
   universal-ctags:


### PR DESCRIPTION
The `home` interface on snap provides access to non-privileged user files/folders in the user's home directory. But sometimes it is necessary for `hidden` files (i.e. files prepended by `.`).

Personally my reason for needing this change is that I use the `universal-ctags` snap in conjunction with the `neotags` plugin for neovim, which requires read/write access to `$HOME/.vim-tags`. This currently fails with permission errors

This provides a fix for the following issues:
* https://github.com/universal-ctags/ctags-snap/issues/4
* https://github.com/universal-ctags/ctags/issues/2017