### PR TITLE
Add .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/parts/
+/prime/
+/snap/.snapcraft/
+/stage/
+/universal-ctags_*_*.snap
+


### PR DESCRIPTION
To prevent intermediate and output files from accidentally being
committed.